### PR TITLE
Add support for returning raw json, and don't require an auth token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ SHELL:=/usr/bin/env bash
 
 .PHONY: lint
 lint:
-	poetry run mypy poe_client tests/**/*.py
+	poetry run mypy poe_client tests
 	poetry run flake8 .
 	poetry run doc8 -q docs
 
+# We don't want to run manual tests in CI, since they expect API credentials to exist.
 .PHONY: unit
 unit:
-	# We don't want to run manual tests in CI, since they expect API credentials to exist.
 	poetry run pytest -m 'not manual'
 
 .PHONY: package

--- a/poe_client/client.py
+++ b/poe_client/client.py
@@ -160,7 +160,7 @@ class Client(object):
         if self._token:
             headers = kwargs["headers"]
             assert headers  # noqa: S101
-            headers["test"] = "Bearer {0}".format(self._token)
+            headers["Authorization"] = "Bearer {0}".format(self._token)
 
         # We key the policy name off the path with no format args. This presumes that
         # different requests to the same endpoints with different specific args use the
@@ -468,7 +468,7 @@ class _PublicStashMixin(Client):
             query["id"] = next_change_id
 
         return await self._get_json(
-            "public-stash-tabs",
+            path="public-stash-tabs",
             query=query,
         )
 

--- a/poe_client/client_test.py
+++ b/poe_client/client_test.py
@@ -23,7 +23,7 @@ class ClientTest(IsolatedAsyncioTestCase):
 
     def setUp(self) -> None:
         """Sets up the test."""
-        self.client = client.PoEClient("token", "test user agent")
+        self.client = client.PoEClient("test user agent", "token")
         self.client._base_url = URL("https://example.com")
         self.client._client = mock.AsyncMock()
         return super().setUp()
@@ -48,6 +48,33 @@ class ClientTest(IsolatedAsyncioTestCase):
             "https://example.com/test",
             headers={
                 "Authorization": "Bearer token",
+                "User-Agent": "test user agent",
+            },
+            params=None,
+            raise_for_status=False,
+        )
+
+    async def test_no_token(self):
+        """Tests not passing a result field argument."""
+        self.client = client.PoEClient("test user agent")
+        self.client._base_url = URL("https://example.com")
+        self.client._client = mock.AsyncMock()
+
+        response_mock = mock.MagicMock()
+        response_mock.status = 200
+        response_mock.headers = {}
+        response_mock.json = mock.AsyncMock(return_value={"thing": "123"})
+        self.client._client.get.return_value.__aenter__.return_value = (  # type: ignore
+            response_mock
+        )
+
+        await self.client._get(
+            model=ModelTest,
+            path="test",
+        )
+        self.client._client.get.assert_called_with(  # type: ignore
+            "https://example.com/test",
+            headers={
                 "User-Agent": "test user agent",
             },
             params=None,
@@ -116,23 +143,23 @@ class PublicStashTest(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         """Setup override."""
         self.client = client.PoEClient("token", "test user agent")
-        self.client._get = mock.AsyncMock()  # type: ignore
+        self.client._get_json = mock.AsyncMock()  # type: ignore
         return super().setUp()
 
     async def test_basic(self):
         """Basic test."""
-        await self.client.get_public_stash_tabs()
-        self.client._get.assert_called_with(  # type: ignore
-            path="public-stash-tabs",
-            model=PublicStash,
-            query={},
-        )
+        async with self.client:
+            await self.client.get_public_stash_tabs()
+            self.client._get_json.assert_called_with(  # type: ignore
+                path="public-stash-tabs",
+                query={},
+            )
 
     async def test_next_change_id(self):
         """Tests the client when you use a next_change_id."""
-        await self.client.get_public_stash_tabs(next_change_id="1234")
-        self.client._get.assert_called_with(  # type: ignore
-            path="public-stash-tabs",
-            model=PublicStash,
-            query={"id": "1234"},
-        )
+        async with self.client:
+            await self.client.get_public_stash_tabs(next_change_id="1234")
+            self.client._get_json.assert_called_with(  # type: ignore
+                path="public-stash-tabs",
+                query={"id": "1234"},
+            )

--- a/poe_client/client_test.py
+++ b/poe_client/client_test.py
@@ -5,7 +5,6 @@ from yarl import URL
 
 from poe_client import client
 from poe_client.schemas import Model
-from poe_client.schemas.stash import PublicStash
 
 
 class ModelTest(Model):
@@ -64,15 +63,13 @@ class ClientTest(IsolatedAsyncioTestCase):
         response_mock.status = 200
         response_mock.headers = {}
         response_mock.json = mock.AsyncMock(return_value={"thing": "123"})
-        self.client._client.get.return_value.__aenter__.return_value = (  # type: ignore
-            response_mock
-        )
+        self.client._client.get.return_value.__aenter__.return_value = response_mock
 
         await self.client._get(
             model=ModelTest,
             path="test",
         )
-        self.client._client.get.assert_called_with(  # type: ignore
+        self.client._client.get.assert_called_with(
             "https://example.com/test",
             headers={
                 "User-Agent": "test user agent",

--- a/poe_client/schemas/stash.py
+++ b/poe_client/schemas/stash.py
@@ -1,3 +1,7 @@
+"""Models for stash tab changes.
+
+THIS IS UNUSED BY THE CLIENT. These models may not actually be accurate.
+"""
 from enum import Enum
 from typing import Dict, List, Optional, Tuple, Union
 


### PR DESCRIPTION
The public stash tab API returns very complicated results which are hard to model with a schema. Returning the json, and not type checking it, can be easier.

This also makes the auth token optional, and only sends it if it's set. GGG allows some access to their API without an auth token.