### PR TITLE
Change most logging to debug

### DIFF
--- a/poe_client/client.py
+++ b/poe_client/client.py
@@ -170,10 +170,10 @@ class Client(object):
             # We ignore typing in the dict assignment. kwargs only has dicts as values,
             # but we're assigning booleans here. We can't set the typing inline without
             # flake8 complaining about overly complex annotation.
-            logging.info("NOT BLOCKING")
+            logging.debug("NOT BLOCKING")
             kwargs["raise_for_status"] = True  # type: ignore
         else:
-            logging.info("BLOCKING")
+            logging.debug("BLOCKING")
             kwargs["raise_for_status"] = False  # type: ignore
 
         # The types are ignored because for some reason it can't understand


### PR DESCRIPTION
Most of the logging messages in the library are only really useful when debugging, and are just noisy info messages. 